### PR TITLE
work on nhp

### DIFF
--- a/neuropacks/nhp/nhp.py
+++ b/neuropacks/nhp/nhp.py
@@ -76,12 +76,7 @@ class NHP:
         y_binned : ndarray
             The mean y position in each bin.
         """
-        # calculate number of bins
-        n_bins = int(np.ceil(
-            (self.timestamps[-1] - self.timestamps[0])/bin_width
-        ))
-        bins = np.arange(n_bins + 1) * bin_width + self.timestamps[0]
-        bin_indices = np.digitize(self.timestamps, bins=bins) - 1
+        bins, bin_indices, n_bins = self.bin_times(bin_width)
 
         cursor_pos_binned = np.zeros((n_bins, 2))
 
@@ -120,11 +115,7 @@ class NHP:
         except KeyError:
             raise ValueError(f'Region {region} is neither M1 nor S1.')
 
-        # calculate number of bins
-        n_bins = int(np.ceil(
-            (self.timestamps[-1] - self.timestamps[0])/bin_width
-        ))
-        bins = np.arange(n_bins + 1) * bin_width + self.timestamps[0]
+        bins, _, n_bins = self.bin_times(bin_width)
 
         Y = np.zeros((n_bins, len(spike_times)))
 
@@ -142,6 +133,16 @@ class NHP:
                 raise ValueError(f'Transform {transform} is not valid.')
 
         return Y
+
+    def bin_times(self, bin_width):
+        # calculate number of bins
+        n_bins = int(np.ceil(
+            (self.timestamps[-1] - self.timestamps[0])/bin_width
+        ))
+
+        bins = np.arange(n_bins + 1) * bin_width + self.timestamps[0]
+        bin_indices = np.digitize(self.timestamps, bins=bins) - 1
+        return bins, bin_indices, n_bins
 
     def _read_chan_names(self, data):
 

--- a/neuropacks/nhp/nhp.py
+++ b/neuropacks/nhp/nhp.py
@@ -17,6 +17,10 @@ class NHP:
         data_path : string
             The path to the NHP dataset.
 
+        chan_names : list
+            List of channel names, formatted as '{region} {channel_idx}',
+            for example 'M1 001'.
+
         timestamps : nd-array, shape (n_timestamps)
             The timestamps, in seconds, for the session.
 
@@ -33,6 +37,9 @@ class NHP:
         n_sorted_units : int
             The number of sorted units per channel. This number excludes the
             unsorted units.
+
+        spike_times : dict
+            Merged dictionary {'M1': M1_spike_times, 'S1': S1_spike_times}.
 
         M1_spike_times : dict
             A dictionary where each key denotes a channel, unit combination in

--- a/neuropacks/nhp/nhp.py
+++ b/neuropacks/nhp/nhp.py
@@ -86,17 +86,16 @@ class NHP:
         y_binned : ndarray
             The mean y position in each bin.
         """
+        return self.bin_timeseries(self.cursor_pos, bin_width=bin_width)
+
+    def bin_timeseries(self, data_ts, bin_width=0.5):
         bins, bin_indices, n_bins = self._bin_times(bin_width)
 
-        cursor_pos_binned = np.zeros((n_bins, 2))
-
+        data_binned = np.zeros((n_bins, 2))
         for bin_idx in range(n_bins):
             indices = np.argwhere(bin_indices == bin_idx).ravel()
-            cursor_pos_binned[bin_idx] = np.mean(
-                self.cursor_pos[:, indices], axis=1
-            ).T
-
-        return cursor_pos_binned
+            data_binned[bin_idx] = np.mean(data_ts[:, indices], axis=1).T
+        return data_binned
 
     def get_response_matrix(self, bin_width, region='M1', transform='sqrt'):
         """Create the response matrix by binning the spike times.

--- a/neuropacks/nhp/nhp.py
+++ b/neuropacks/nhp/nhp.py
@@ -62,11 +62,11 @@ class NHP:
         self.finger_pos = data['finger_pos'][:]
 
         self.spike_times, self.n_sorted_units = self._read_spike_times(data)
+        data.close()
+
         # keep legacy attributes
         self.M1_spike_times = self.spike_times['M1']
         self.S1_spike_times = self.spike_times['S1']
-
-        data.close()
 
         self.trials, self.target_grid = self._parse_trials()
 
@@ -143,6 +143,11 @@ class NHP:
                 raise ValueError(f'Transform {transform} is not valid.')
 
         return Y
+
+    def get_binned_times(self, bin_width):
+        bins, _, _ = self._bin_times(bin_width)
+        times_bin_center = (bins[1:] + bins[:-1]) / 2
+        return times_bin_center
 
     def _bin_times(self, bin_width):
         # calculate number of bins

--- a/neuropacks/nhp/nhp.py
+++ b/neuropacks/nhp/nhp.py
@@ -83,7 +83,7 @@ class NHP:
         y_binned : ndarray
             The mean y position in each bin.
         """
-        bins, bin_indices, n_bins = self.bin_times(bin_width)
+        bins, bin_indices, n_bins = self._bin_times(bin_width)
 
         cursor_pos_binned = np.zeros((n_bins, 2))
 
@@ -122,7 +122,7 @@ class NHP:
         except KeyError:
             raise ValueError(f'Region {region} is neither M1 nor S1.')
 
-        bins, _, n_bins = self.bin_times(bin_width)
+        bins, _, n_bins = self._bin_times(bin_width)
 
         Y = np.zeros((n_bins, len(spike_times)))
 
@@ -141,7 +141,7 @@ class NHP:
 
         return Y
 
-    def bin_times(self, bin_width):
+    def _bin_times(self, bin_width):
         # calculate number of bins
         n_bins = int(np.ceil(
             (self.timestamps[-1] - self.timestamps[0])/bin_width

--- a/neuropacks/nhp/nhp.py
+++ b/neuropacks/nhp/nhp.py
@@ -47,6 +47,7 @@ class NHP:
         # open up .mat file
         self.data_path = data_path
         data = h5py.File(data_path, 'r')
+        self.chan_names = self._read_chan_names(data)
         self.timestamps = data['t'][0, :]
         self.cursor_pos = data['cursor_pos'][:]
         self.target_pos = data['target_pos'][:]
@@ -172,3 +173,14 @@ class NHP:
                 raise ValueError('Transform %s is not valid.' % transform)
 
         return Y
+
+    def _read_chan_names(self, data):
+
+        def decode_str(int_list):
+            ''' interpret an array of integers to a string,
+            assuming Unicode.
+            '''
+            return ''.join([chr(int(i)) for i in int_list])
+
+        return [decode_str(data[ref][:])
+                for ref in data['chan_names'][:].squeeze()]

--- a/neuropacks/nhp/nhp.py
+++ b/neuropacks/nhp/nhp.py
@@ -93,9 +93,7 @@ class NHP:
 
         return cursor_pos_binned
 
-    def get_response_matrix(
-        self, bin_width, region='M1', transform='square_root'
-    ):
+    def get_response_matrix(self, bin_width, region='M1', transform='sqrt'):
         """Create the response matrix by binning the spike times.
 
         Parameters
@@ -107,8 +105,9 @@ class NHP:
             The region to create a response matrix for ('M1' or 'S1').
 
         transform : string
-            The transform to apply to the spike counts. Available option is
-            'square_root'. If None, no transform is applied.
+            The transform to apply to the spike counts.
+            Available option is 'square_root' (abbrev. 'sqrt').
+            If None, no transform is applied.
 
         Returns
         -------
@@ -137,10 +136,10 @@ class NHP:
             # apply a transform
             if transform is None:
                 Y[:, idx] = binned_spike_counts
-            elif transform == 'square_root':
+            elif transform in ('sqrt', 'square_root'):
                 Y[:, idx] = np.sqrt(binned_spike_counts)
             else:
-                raise ValueError('Transform %s is not valid.' % transform)
+                raise ValueError(f'Transform {transform} is not valid.')
 
         return Y
 


### PR DESCRIPTION
- refactor existing methods for binning curser positions and responses (user interface for existing methods did not change)
- store all spike times as a single attribute `.spike_times` (in addition to separate `M1_spike_times` and `S1_spike_times`)
- add trials table as attribute `.trials`, as well as `.target_grid`