### PR TITLE
work on common utils for binning spike counts

### DIFF
--- a/neuropacks/nhp/nhp.py
+++ b/neuropacks/nhp/nhp.py
@@ -155,7 +155,7 @@ class NHP:
 
         bins, _, n_bins = self._bin_times(bin_width)
         spike_times_array = [spikes for key, spikes in spike_times.items()]
-        Y = bin_spike_times(spike_times_array, bins, transform=transform)
+        Y = bin_spike_times(spike_times_array, bins, apply_transform=transform)
         return Y
 
     def get_binned_times(self, bin_width=0.5):

--- a/neuropacks/nhp/nhp.py
+++ b/neuropacks/nhp/nhp.py
@@ -2,7 +2,7 @@ import h5py
 import numpy as np
 import pandas as pd
 
-from neuropacks.utils.binning import bin_spike_times
+from neuropacks.utils.binning import bin_spike_times, create_bins
 
 
 class NHP:
@@ -176,12 +176,10 @@ class NHP:
         return times_bin_center
 
     def _bin_times(self, bin_width):
-        # calculate number of bins
-        n_bins = int(np.ceil(
-            (self.timestamps[-1] - self.timestamps[0])/bin_width
-        ))
-
-        bins = np.arange(n_bins + 1) * bin_width + self.timestamps[0]
+        bins = create_bins(t_start=self.timestamps[0],
+                           t_stop=self.timestamps[-1],
+                           bin_width=bin_width)
+        n_bins = len(bins) - 1
         bin_indices = np.digitize(self.timestamps, bins=bins) - 1
         return bins, bin_indices, n_bins
 

--- a/neuropacks/nhp/nhp.py
+++ b/neuropacks/nhp/nhp.py
@@ -176,9 +176,7 @@ class NHP:
         return times_bin_center
 
     def _bin_times(self, bin_width):
-        bins = create_bins(t_start=self.timestamps[0],
-                           t_stop=self.timestamps[-1],
-                           bin_width=bin_width)
+        bins = create_bins(self.timestamps[0], self.timestamps[-1], bin_width)
         n_bins = len(bins) - 1
         bin_indices = np.digitize(self.timestamps, bins=bins) - 1
         return bins, bin_indices, n_bins

--- a/neuropacks/peanut/data_manager.py
+++ b/neuropacks/peanut/data_manager.py
@@ -536,17 +536,18 @@ def get_spike_rates(unit_spiking_times, bins,
                     boxcox=0.5, log=None,
                     filter_fn='none', **filter_kwargs):
     if filter_fn == 'none':
-        filter = {}
+        apply_filter = {}
     elif filter_fn == 'gaussian':
         bin_width = bins[1] - bins[0]
         sigma = filter_kwargs['sigma'] / bin_width  # convert to unit of bins
         # sigma = min(1, sigma) # -- ??
-        filter = {'gaussian': sigma}
+        apply_filter = {'gaussian': sigma}
     else:
         raise ValueError(f'unknown filter_fn: got {filter_fn}')
 
-    transform = {'boxcox': boxcox, 'log': log}
+    apply_transform = {'boxcox': boxcox, 'log': log}
 
     spike_rates = bin_spike_times(unit_spiking_times, bins,
-                                  transform=transform, filter=filter)
+                                  apply_transform=apply_transform,
+                                  apply_filter=apply_filter)
     return spike_rates

--- a/neuropacks/peanut/data_manager.py
+++ b/neuropacks/peanut/data_manager.py
@@ -1,13 +1,13 @@
 import os
 import numpy as np
 import pandas as pd
-import pickle
 from copy import deepcopy
 
 from .task import get_traj_outcomes
 
-from neuropacks.utils.binning import (
-    create_bins, bin_spike_times, downsample_by_interp)
+from neuropacks.utils.binning import create_bins, bin_spike_times
+from neuropacks.utils.io import load_pickle
+from neuropacks.utils.signal import downsample_by_interp
 
 
 class DayDataManager():
@@ -474,10 +474,6 @@ class Peanut_SingleEpoch(EpochDataManager):
     def __init__(self, path, *, day, epoch):
         # Note: for peanut_day14, the rat is running during even numbered epochs.
         super().__init__(path, animal='peanut', day=day, epoch=epoch)
-
-
-def load_pickle(filename):
-    return pickle.load(open(filename, 'rb'))
 
 
 def get_binned_times_rates_pos(t, unit_spiking_times, pos_linear,

--- a/neuropacks/utils/binning.py
+++ b/neuropacks/utils/binning.py
@@ -54,35 +54,131 @@ def get_spike_rates(unit_spiking_times, bins,
                     boxcox=0.5, log=None,
                     filter_fn='none', **filter_kwargs):
     if filter_fn == 'none':
-
-        def do_nothing(x, **kwargs):
-            ''' do nothing and just return the input argument '''
-            return x
-
-        _filter = do_nothing
-
+        filter = {}
     elif filter_fn == 'gaussian':
-        _filter = gaussian_filter1d
         bin_width = bins[1] - bins[0]
-        filter_kwargs['sigma'] /= bin_width  # convert to unit of bins
-        # filter_kwargs['sigma'] = min(1, filter_kwargs['sigma']) # -- ??
-
+        sigma = filter_kwargs['sigma'] / bin_width  # convert to unit of bins
+        # sigma = min(1, sigma) # -- ??
+        filter = {'gaussian': sigma}
     else:
         raise ValueError(f'unknown filter_fn: got {filter_fn}')
 
+    transform = {'boxcox': boxcox, 'log': log}
+
+    spike_rates = bin_spike_times(unit_spiking_times, bins,
+                                  transform=transform, filter=filter)
+    return spike_rates
+
+
+def bin_spike_times(spike_times_by_units, bins, transform={}, filter={}):
+    """Bin the spike times from each single unit, and optionally apply
+    transform and filtering on the binned spike counts.
+
+    Parameters
+    ----------
+    spike_times_by_units : iterable (first over units, then over spikes)
+        Either a list of arrays where each array stores spike times from a unit,
+        or a 2D array with shape (n_units, spikes).
+
+    bins : ndarray
+        Timepoints at bin boundaries. This array should have shape (n_bin + 1, )
+        where n_bin is the number of timepoints in the output spike_rates.
+
+    transform: function or dictionary
+        Specifies an element-wise transformation (same operation for each time)
+        for the binned spike counts from each unit.
+
+    filter: function or dictionary
+        Specifies a filtering operation (across the time axis)
+        for the binned spike counts from each unit.
+
+    Returns
+    -------
+    spike_rates: ndarray, shape (n_bins, n_units)
+        Binned, transformed and filtered spike counts from each unit.
+    """
+    # if a transform function is provided, use it directly; otherwise build
+    if not callable(transform):
+        if transform is None:
+            transform = {}
+        if not isinstance(transform, dict):
+            raise TypeError('transform should be either a function or a dictionary.')
+        transform = build_transform(**transform)
+
+    # if a filtering function is provided, use it directly; otherwise build
+    if not callable(filter):
+        if filter is None:
+            filter = {}
+        if not isinstance(filter, dict):
+            raise TypeError('filter should be either a function or a dictionary.')
+        filter = build_filter(**filter)
+
+    # bin spike times, then apply optional transform and filter
     all_rates_list = []
-    for spike_times in unit_spiking_times:
+    for spike_times in spike_times_by_units:
         spike_counts = np.histogram(spike_times, bins=bins)[0]
-        if boxcox is not None:
-            spike_counts = np.array(
-                [box_cox(spike_count, boxcox) for spike_count in spike_counts])
-        if log is not None:
-            spike_counts = np.array(
-                [np.log(spike_count) / np.log(log) for spike_count in spike_counts])
-        rates = _filter(spike_counts.astype(np.float), **filter_kwargs)
+        # apply transforms to spike counts at each timepoint
+        spike_counts = transform(spike_counts)
+        # apply filtering across timepoints (e.g. gaussian smoothing)
+        rates = filter(spike_counts)
         all_rates_list.append(rates)
+
     spike_rates = np.stack(all_rates_list, axis=1)
     return spike_rates
+
+
+def build_transform(boxcox=None, log=None, filter={}):
+    """Build and return a function that transforms spike counts.
+
+    Parameters
+    ----------
+    boxcox : float (or None)
+        If a value is given, apply a boxcox transform with this parameter value.
+    log : float (or None)
+        If a value is given, take a log with this value as the log base.
+
+    Returns
+    -------
+    transform : function
+        Function that takes a 1D ndarray as input, and applies the same transform
+        to each element of the array.
+    """
+    def transform(x_traj):
+        ''' x_traj is a 1D ndarray. '''
+        if boxcox is not None:
+            return np.array([box_cox(x, boxcox) for x in x_traj])
+
+        if log is not None:
+            return np.array([np.log(x) / np.log(log) for x in x_traj])
+
+        # otherwise do nothing
+        return x_traj
+
+    return transform
+
+
+def build_filter(gaussian=None):
+    """Build and return a function that applies filtering to a 1D timeseries.
+
+    Parameters
+    ----------
+    gaussian : float (or None)
+        If a value is given, apply gaussian filtering with this value as sigma.
+
+    Returns
+    -------
+    transform : function
+        Function that takes a 1D ndarray as input, applies specified filtering,
+        and returns the filtered array with the same shape.
+    """
+    def filter(x_traj):
+        ''' x_traj is a 1D ndarray. '''
+        if gaussian is not None:
+            return gaussian_filter1d(x_traj, sigma=gaussian)
+        # otherwise do nothing
+        return x_traj
+
+    return filter
 
 
 def box_cox(x, power_param):

--- a/neuropacks/utils/binning.py
+++ b/neuropacks/utils/binning.py
@@ -30,7 +30,15 @@ def create_bins(t_start, t_end, bin_width, bin_type='time'):
     """
     T = t_end - t_start
     if bin_type == 'time':
-        bins = np.linspace(t_start, t_end, int(T // bin_width))
+        # Bug: the number was off by 1 here, because the endpoint is included.
+        # More general issue with linspace: When T is not an exactly multiple
+        # of bin_width, the resulting bins may not have the requested bin_width.
+        # ---
+        # bins = np.linspace(t_start, t_end, int(T // bin_width))
+
+        # fixed to use exact bin widths
+        n_bins = int(np.ceil(T / bin_width))
+        bins = t_start + bin_width * np.arange(n_bins + 1)
     else:
         raise ValueError('unknown bin_type')
     return bins

--- a/neuropacks/utils/binning.py
+++ b/neuropacks/utils/binning.py
@@ -6,6 +6,28 @@ from neuropacks.utils.signal import box_cox
 
 
 def create_bins(t_start, t_end, bin_width, bin_type='time'):
+    """Create bins for the specified time interval.
+
+    Parameters
+    ----------
+    t_start : float
+        Start time, in an appropriate unit of time (for example seconds).
+        This corresponds to the first value of the output bins.
+    t_end : float
+        End time, in the same unit as the t_start unit.
+        This corresponds to the last value of the output bins.
+    bin_width : float
+        Bin width, in the same unit as the t_start unit.
+    bin_type : str
+        How to balance the bin sizes. For now the only option is 'time'.
+        If 'time', bins have uniform lengths (bin_width) in time.
+
+    Returns
+    -------
+    bins : ndarray, shape (n_bin + 1, )
+        A sequence of time values that starts with t_start and ends with t_end.
+        This gives (n_bins + 1) boundary values that define n_bin intervals.
+    """
     T = t_end - t_start
     if bin_type == 'time':
         bins = np.linspace(t_start, t_end, int(T // bin_width))

--- a/neuropacks/utils/binning.py
+++ b/neuropacks/utils/binning.py
@@ -1,7 +1,8 @@
 import numpy as np
 
-from scipy.interpolate import interp1d
 from scipy.ndimage import gaussian_filter1d
+
+from neuropacks.utils.signal import box_cox
 
 
 def create_bins(t_start, t_end, bin_width, bin_type='time'):
@@ -122,14 +123,3 @@ def build_filter(gaussian=None):
         return x_traj
 
     return filter
-
-
-def box_cox(x, power_param):
-    ''' one-parameter Box-Cox transformation '''
-    return (np.power(x, power_param) - 1) / power_param
-
-
-def downsample_by_interp(x, t, t_samp):
-    interpolator = interp1d(t, x)
-    x_samp = interpolator(t_samp)
-    return x_samp

--- a/neuropacks/utils/binning.py
+++ b/neuropacks/utils/binning.py
@@ -14,7 +14,8 @@ def create_bins(t_start, t_end, bin_width, bin_type='time'):
     return bins
 
 
-def bin_spike_times(spike_times_by_units, bins, transform={}, filter={}):
+def bin_spike_times(spike_times_by_units, bins,
+                    apply_transform={}, apply_filter={}):
     """Bin the spike times from each single unit, and optionally apply
     transform and filtering on the binned spike counts.
 
@@ -28,11 +29,11 @@ def bin_spike_times(spike_times_by_units, bins, transform={}, filter={}):
         Timepoints at bin boundaries. This array should have shape (n_bin + 1, )
         where n_bin is the number of timepoints in the output spike_rates.
 
-    transform: function or dictionary
+    apply_transform: function or dictionary
         Specifies an element-wise transformation (same operation for each time)
         for the binned spike counts from each unit.
 
-    filter: function or dictionary
+    apply_filter: function or dictionary
         Specifies a filtering operation (across the time axis)
         for the binned spike counts from each unit.
 
@@ -42,29 +43,29 @@ def bin_spike_times(spike_times_by_units, bins, transform={}, filter={}):
         Binned, transformed and filtered spike counts from each unit.
     """
     # if a transform function is provided, use it directly; otherwise build
-    if not callable(transform):
-        if transform is None:
-            transform = {}
-        if not isinstance(transform, dict):
-            raise TypeError('transform should be either a function or a dictionary.')
-        transform = build_transform(**transform)
+    if not callable(apply_transform):
+        if apply_transform is None:
+            apply_transform = {}
+        if not isinstance(apply_transform, dict):
+            raise TypeError('apply_transform should be either a function or a dictionary.')
+        apply_transform = build_transform(**apply_transform)
 
     # if a filtering function is provided, use it directly; otherwise build
-    if not callable(filter):
-        if filter is None:
-            filter = {}
-        if not isinstance(filter, dict):
-            raise TypeError('filter should be either a function or a dictionary.')
-        filter = build_filter(**filter)
+    if not callable(apply_filter):
+        if apply_filter is None:
+            apply_filter = {}
+        if not isinstance(apply_filter, dict):
+            raise TypeError('apply_filter should be either a function or a dictionary.')
+        apply_filter = build_filter(**apply_filter)
 
     # bin spike times, then apply optional transform and filter
     all_rates_list = []
     for spike_times in spike_times_by_units:
         spike_counts = np.histogram(spike_times, bins=bins)[0]
-        # apply transforms to spike counts at each timepoint
-        spike_counts = transform(spike_counts)
-        # apply filtering across timepoints (e.g. gaussian smoothing)
-        rates = filter(spike_counts)
+        # apply transform to spike counts at each timepoint
+        spike_counts = apply_transform(spike_counts)
+        # apply filter across timepoints (e.g. gaussian smoothing)
+        rates = apply_filter(spike_counts)
         all_rates_list.append(rates)
 
     spike_rates = np.stack(all_rates_list, axis=1)
@@ -83,11 +84,11 @@ def build_transform(boxcox=None, log=None, filter={}):
 
     Returns
     -------
-    transform : function
+    _transform : function
         Function that takes a 1D ndarray as input, and applies the same transform
         to each element of the array.
     """
-    def transform(x_traj):
+    def _transform(x_traj):
         ''' x_traj is a 1D ndarray. '''
         if boxcox is not None:
             return np.array([box_cox(x, boxcox) for x in x_traj])
@@ -98,7 +99,7 @@ def build_transform(boxcox=None, log=None, filter={}):
         # otherwise do nothing
         return x_traj
 
-    return transform
+    return _transform
 
 
 def build_filter(gaussian=None):
@@ -111,15 +112,15 @@ def build_filter(gaussian=None):
 
     Returns
     -------
-    transform : function
+    _filter : function
         Function that takes a 1D ndarray as input, applies specified filtering,
         and returns the filtered array with the same shape.
     """
-    def filter(x_traj):
+    def _filter(x_traj):
         ''' x_traj is a 1D ndarray. '''
         if gaussian is not None:
             return gaussian_filter1d(x_traj, sigma=gaussian)
         # otherwise do nothing
         return x_traj
 
-    return filter
+    return _filter

--- a/neuropacks/utils/binning.py
+++ b/neuropacks/utils/binning.py
@@ -25,14 +25,7 @@ def spike_times_to_rates(unit_spiking_times, bins=None,
         bins = create_bins(t_start=t_start, t_end=t_end, bin_width=bin_width,
                            bin_type='time')
 
-    if bin_rep == 'center':
-        t_binned = bins[:-1] + bin_width / 2  # midpoints
-    elif bin_rep == 'left':
-        t_binned = bins[:-1]    # left endpoints
-    elif bin_rep == 'right':
-        t_binned = bins[1:]     # right endpoints
-    else:
-        raise ValueError('bin_rep should be one of center, left or right.')
+    t_binned = get_binned_times(bins=bins, bin_rep=bin_rep)
 
     # get spike rates time series from unit spike times
     spike_rates = get_spike_rates(unit_spiking_times, bins,
@@ -48,6 +41,24 @@ def create_bins(t_start, t_end, bin_width, bin_type='time'):
     else:
         raise ValueError('unknown bin_type')
     return bins
+
+
+def get_binned_times(bins=None, bin_rep='center',
+                     t_start=None, t_end=None, bin_width=None, bin_type='time'):
+    if bins is None:
+        bins = create_bins(t_start=t_start, t_end=t_end, bin_width=bin_width,
+                           bin_type=bin_type)
+
+    # assign a representative time value to each bin
+    if bin_rep == 'center':
+        return (bins[1:] + bins[:-1]) / 2  # midpoints
+    elif bin_rep == 'left':
+        return bins[:-1]    # left endpoints
+    elif bin_rep == 'right':
+        return bins[1:]     # right endpoints
+
+    raise ValueError('bin_rep should be one of (center, left, right); '
+                     f'got {bin_rep}.')
 
 
 def get_spike_rates(unit_spiking_times, bins,

--- a/neuropacks/utils/io.py
+++ b/neuropacks/utils/io.py
@@ -1,0 +1,5 @@
+import pickle
+
+
+def load_pickle(filename):
+    return pickle.load(open(filename, 'rb'))

--- a/neuropacks/utils/signal.py
+++ b/neuropacks/utils/signal.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from scipy.interpolate import interp1d
+
+
+def box_cox(x, power_param):
+    ''' one-parameter Box-Cox transformation '''
+    return (np.power(x, power_param) - 1) / power_param
+
+
+def downsample_by_interp(x, t, t_samp):
+    interpolator = interp1d(t, x)
+    x_samp = interpolator(t_samp)
+    return x_samp


### PR DESCRIPTION
the common binning functions live in `neuropacks.utils`

these subpackages are also updated to use the common binning utils:
- `neuropacks.nhp`
- `neuropacks.peanut`